### PR TITLE
fix: 🐛 GitHub Pages用のベースパスを追加

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
     root: '.',
+    base: '/CatSlayer/',
     publicDir: 'public',
     server: {
         port: 3000,


### PR DESCRIPTION
## 変更内容\n\n- vite.config.tsにGitHub Pages用のベースパスを追加\n  - base: '/CatSlayer/'を設定\n  - これにより、GitHub Pagesでの正しいアセットパスが設定される\n\n## 期待される結果\n- GitHub Pagesでのデプロイが正常に動作\n- アセットが正しく読み込まれる\n\n## 動作確認\n- ローカルでのビルドとプレビューで動作確認済み